### PR TITLE
workaround InvalidCastException on Mono

### DIFF
--- a/Source/SDK/Manager/ConfigManager.cs
+++ b/Source/SDK/Manager/ConfigManager.cs
@@ -54,22 +54,25 @@ namespace PayPal.Api
                 return singletonInstance;
             }
         }
+
         /// <summary>
         /// Private constructor
         /// </summary>
         private ConfigManager()
         {
-            SDKConfigHandler configHandler = (SDKConfigHandler)ConfigurationManager.GetSection("paypal");
+            SDKConfigHandler configHandler = (SDKConfigHandler) ConfigurationManager.GetSection("paypal");
             if (configHandler == null)
             {
-                throw new ConfigException("Cannot parse *.Config file. Ensure you have configured the 'paypal' section correctly.");
+                throw new ConfigException(
+                    "Cannot parse *.Config file. Ensure you have configured the 'paypal' section correctly.");
             }
-            this.configValues = new Dictionary<string, string>();
 
             NameValueConfigurationCollection settings = configHandler.Settings;
-            foreach (string key in settings.AllKeys)
+            this.configValues = new Dictionary<string, string>();
+            foreach (var setting in settings)
             {
-                this.configValues.Add(settings[key].Name, settings[key].Value);
+                var set = (System.Configuration.NameValueConfigurationElement) setting;
+                configValues.Add(set.Name, set.Value);
             }
 
             int index = 0;

--- a/Source/SDK/Manager/ConfigManager.cs
+++ b/Source/SDK/Manager/ConfigManager.cs
@@ -69,10 +69,9 @@ namespace PayPal.Api
 
             NameValueConfigurationCollection settings = configHandler.Settings;
             this.configValues = new Dictionary<string, string>();
-            foreach (var setting in settings)
-            {
-                var set = (System.Configuration.NameValueConfigurationElement) setting;
-                configValues.Add(set.Name, set.Value);
+            foreach (NameValueConfigurationElement setting in settings)
+            {                
+                configValues.Add(setting.Name, setting.Value);
             }
 
             int index = 0;


### PR DESCRIPTION
PayPal .NET SDK is not usable on mono, since the ConfigManager makes use of ``NameValueConfigurationCollection.AllKeys`` property which is broken on Mono (see Mono bug https://bugzilla.novell.com/show_bug.cgi?id=643379 )

This workaround makes it possible to use the SDK on Mono
