### PR TITLE
sdk-enhancement

### DIFF
--- a/Source/SDK/Api/Sale.cs
+++ b/Source/SDK/Api/Sale.cs
@@ -42,6 +42,18 @@ namespace PayPal.Api
         public string payment_mode { get; set; }
 
         /// <summary>
+        /// your own invoice number or tracking IDs, Maximum length: 127.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "invoice_number")]
+        public string invoice_number { get; set; }
+
+        /// <summary>
+        /// free-form field for the use of clients, Maximum length: 127.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "custom")]
+        public string custom { get; set; }
+        
+        /// <summary>
         /// State of the sale transaction.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "state")]

--- a/Source/SDK/Api/WebhookEvent.cs
+++ b/Source/SDK/Api/WebhookEvent.cs
@@ -46,6 +46,12 @@ namespace PayPal.Api
         public string event_type { get; set; }
 
         /// <summary>
+        /// The version of the event.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "event_version")]
+        public string event_version { get; set; }
+
+        /// <summary>
         /// A summary description of the event. E.g. A successful payment authorization was created for $$
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "summary")]


### PR DESCRIPTION
Add missing  "invoice_number" and "custom" fields into Sale.cs for chargeback type transaction
Add missing "event_version" field into WebhookEvent.cs

(Issues number: #200)