### PR TITLE
Remove PayPal-Request-ID from being sent by default

### DIFF
--- a/Source/SDK/Api/APIContext.cs
+++ b/Source/SDK/Api/APIContext.cs
@@ -13,7 +13,6 @@ namespace PayPal.Api
         /// </summary>
         public APIContext()
         {
-            this.ResetRequestId();
             this.SdkVersion = new SDKVersion();
         }
 

--- a/Source/SDK/Api/BankAccount.cs
+++ b/Source/SDK/Api/BankAccount.cs
@@ -226,7 +226,6 @@ namespace PayPal.Api
             ArgumentValidator.Validate(bankAccountId, "bankAccountId");
 
             // Configure and send the request
-            apiContext.MaskRequestId = true;
             var pattern = "v1/vault/bank-accounts/{0}";
             var resourcePath = SDKUtil.FormatURIPath(pattern, new object[] { bankAccountId });
             PayPalResource.ConfigureAndExecute(apiContext, HttpMethod.DELETE, resourcePath);

--- a/Source/SDK/Api/CreditCard.cs
+++ b/Source/SDK/Api/CreditCard.cs
@@ -184,7 +184,6 @@ namespace PayPal.Api
             ArgumentValidator.Validate(creditCardId, "creditCardId");
 
             // Configure and send the request
-            apiContext.MaskRequestId = true;
             var pattern = "v1/vault/credit-cards/{0}";
             var resourcePath = SDKUtil.FormatURIPath(pattern, new object[] { creditCardId });
             PayPalResource.ConfigureAndExecute(apiContext, HttpMethod.DELETE, resourcePath);

--- a/Source/SDK/Api/Invoice.cs
+++ b/Source/SDK/Api/Invoice.cs
@@ -476,7 +476,6 @@ namespace PayPal.Api
             ArgumentValidator.Validate(invoiceId, "invoiceId");
 
             // Configure and send the request
-            apiContext.MaskRequestId = true;
             var pattern = "v1/invoicing/invoices/{0}";
             var resourcePath = SDKUtil.FormatURIPath(pattern, new object[] { invoiceId });
             PayPalResource.ConfigureAndExecute(apiContext, HttpMethod.DELETE, resourcePath);

--- a/Source/SDK/Api/WebProfile.cs
+++ b/Source/SDK/Api/WebProfile.cs
@@ -188,7 +188,6 @@ namespace PayPal.Api
             ArgumentValidator.Validate(profileId, "profileId");
 
             // Configure and send the request
-            apiContext.MaskRequestId = true;
             var pattern = "v1/payment-experience/web-profiles/{0}";
             var resourcePath = SDKUtil.FormatURIPath(pattern, new object[] { profileId });
             PayPalResource.ConfigureAndExecute(apiContext, HttpMethod.DELETE, resourcePath);

--- a/Source/SDK/Api/Webhook.cs
+++ b/Source/SDK/Api/Webhook.cs
@@ -156,7 +156,6 @@ namespace PayPal.Api
             ArgumentValidator.Validate(webhookId, "webhookId");
 
             // Configure and send the request
-            apiContext.MaskRequestId = true;
             var pattern = "v1/notifications/webhooks/{0}";
             var resourcePath = SDKUtil.FormatURIPath(pattern, new object[] { webhookId });
             PayPalResource.ConfigureAndExecute(apiContext, HttpMethod.DELETE, resourcePath);

--- a/Source/SDK/HttpConnection.cs
+++ b/Source/SDK/HttpConnection.cs
@@ -184,10 +184,6 @@ namespace PayPal.Api
         /// <returns>A string containing the response from the remote host.</returns>
         public string Execute(string payLoad, HttpWebRequest httpRequest)
         {
-            int retriesConfigured = config.ContainsKey(BaseConstants.HttpConnectionRetryConfig) ?
-                   Convert.ToInt32(config[BaseConstants.HttpConnectionRetryConfig]) : 0;
-            int retries = 0;
-
             // Reset the request & response details
             this.RequestDetails.Reset();
             this.ResponseDetails.Reset();
@@ -202,132 +198,125 @@ namespace PayPal.Api
             {
                 do
                 {
-                    if (retries > 0)
-                    {
-                        logger.Info("Retrying....");
-                        httpRequest = CopyRequest(httpRequest, config, httpRequest.RequestUri.ToString());
-                        this.RequestDetails.RetryAttempts++;
-                    }
-                    try
-                    {
-                        switch (httpRequest.Method)
-                        {
-                            case "POST":
-                            case "PUT":
-                            case "PATCH":
-                                using (StreamWriter writerStream = new StreamWriter(httpRequest.GetRequestStream()))
-                                {
-                                    writerStream.Write(payLoad);
-                                    writerStream.Flush();
-                                    writerStream.Close();
+                  try
+                  {
+                      switch (httpRequest.Method)
+                      {
+                          case "POST":
+                          case "PUT":
+                          case "PATCH":
+                              using (StreamWriter writerStream = new StreamWriter(httpRequest.GetRequestStream()))
+                              {
+                                  writerStream.Write(payLoad);
+                                  writerStream.Flush();
+                                  writerStream.Close();
 
-                                    if (ConfigManager.IsLiveModeEnabled(config))
-                                    {
-                                        logger.Debug("Request details are hidden in live mode.");
-                                    }
-                                    else
-                                    {
-                                        logger.Debug(payLoad);
-                                    }
-                                }
-                                break;
+                                  if (ConfigManager.IsLiveModeEnabled(config))
+                                  {
+                                      logger.Debug("Request details are hidden in live mode.");
+                                  }
+                                  else
+                                  {
+                                      logger.Debug(payLoad);
+                                  }
+                              }
+                              break;
 
-                            default:
-                                break;
-                        }
+                          default:
+                              break;
+                      }
 
-                        using (WebResponse responseWeb = httpRequest.GetResponse())
-                        {
-                            // Store the response information
-                            this.ResponseDetails.Headers = responseWeb.Headers;
-                            if(responseWeb is HttpWebResponse)
-                            {
-                                this.ResponseDetails.StatusCode = ((HttpWebResponse)responseWeb).StatusCode;
-                            }
+                      using (WebResponse responseWeb = httpRequest.GetResponse())
+                      {
+                          // Store the response information
+                          this.ResponseDetails.Headers = responseWeb.Headers;
+                          if(responseWeb is HttpWebResponse)
+                          {
+                              this.ResponseDetails.StatusCode = ((HttpWebResponse)responseWeb).StatusCode;
+                          }
 
-                            using (StreamReader readerStream = new StreamReader(responseWeb.GetResponseStream()))
-                            {
-                                this.ResponseDetails.Body = readerStream.ReadToEnd().Trim();
+                          using (StreamReader readerStream = new StreamReader(responseWeb.GetResponseStream()))
+                          {
+                              this.ResponseDetails.Body = readerStream.ReadToEnd().Trim();
 
-                                if (ConfigManager.IsLiveModeEnabled(config))
-                                {
-                                    logger.Debug("Response details are hidden in live mode.");
-                                }
-                                else
-                                {
-                                    logger.Debug("Service response: ");
-                                    logger.Debug(this.ResponseDetails.Body);
-                                }
-                                return this.ResponseDetails.Body;
-                            }
-                        }
-                    }
-                    catch (WebException ex)
-                    {
-                        // If provided, get and log the response from the remote host.
-                        var response = string.Empty;
-                        if (ex.Response != null)
-                        {
-                            using (var readerStream = new StreamReader(ex.Response.GetResponseStream()))
-                            {
-                                response = readerStream.ReadToEnd().Trim();
-                                logger.Error("Error response:");
-                                logger.Error(response);
-                            }
-                        }
-                        logger.Error(ex.Message);
+                              if (ConfigManager.IsLiveModeEnabled(config))
+                              {
+                                  logger.Debug("Response details are hidden in live mode.");
+                              }
+                              else
+                              {
+                                  logger.Debug("Service response: ");
+                                  logger.Debug(this.ResponseDetails.Body);
+                              }
+                              return this.ResponseDetails.Body;
+                          }
+                      }
+                  }
+                  catch (WebException ex)
+                  {
+                      // If provided, get and log the response from the remote host.
+                      var response = string.Empty;
+                      if (ex.Response != null)
+                      {
+                          using (var readerStream = new StreamReader(ex.Response.GetResponseStream()))
+                          {
+                              response = readerStream.ReadToEnd().Trim();
+                              logger.Error("Error response:");
+                              logger.Error(response);
+                          }
+                      }
+                      logger.Error(ex.Message);
 
-                        ConnectionException rethrowEx = null;
+                      ConnectionException rethrowEx = null;
 
-                        // Protocol errors indicate the remote host received the
-                        // request, but responded with an error (usually a 4xx or
-                        // 5xx error).
-                        if (ex.Status == WebExceptionStatus.ProtocolError)
-                        {
-                            var httpWebResponse = (HttpWebResponse)ex.Response;
+                      // Protocol errors indicate the remote host received the
+                      // request, but responded with an error (usually a 4xx or
+                      // 5xx error).
+                      if (ex.Status == WebExceptionStatus.ProtocolError)
+                      {
+                          var httpWebResponse = (HttpWebResponse)ex.Response;
 
-                            // If the HTTP status code is flagged as one where we
-                            // should continue retrying, then ignore the exception
-                            // and continue with the retry attempt.
-                            if(httpWebResponse.StatusCode == HttpStatusCode.GatewayTimeout ||
-                               httpWebResponse.StatusCode == HttpStatusCode.RequestTimeout ||
-                               httpWebResponse.StatusCode == HttpStatusCode.BadGateway)
-                            {
-                                continue;
-                            }
+                          // If the HTTP status code is flagged as one where we
+                          // should continue retrying, then ignore the exception
+                          // and continue with the retry attempt.
+                          if(httpWebResponse.StatusCode == HttpStatusCode.GatewayTimeout ||
+                             httpWebResponse.StatusCode == HttpStatusCode.RequestTimeout ||
+                             httpWebResponse.StatusCode == HttpStatusCode.BadGateway)
+                          {
+                              continue;
+                          }
 
-                            rethrowEx = new HttpException(ex.Message, response, httpWebResponse.StatusCode, ex.Status, httpWebResponse.Headers, httpRequest);
-                        }
-                        else if(ex.Status == WebExceptionStatus.ReceiveFailure ||
-                                ex.Status == WebExceptionStatus.ConnectFailure ||
-                                ex.Status == WebExceptionStatus.KeepAliveFailure)
-                        {
-                            logger.Debug("There was a problem connecting to the server: " + ex.Status.ToString());
-                            continue;
-                        }
-                        else if (ex.Status == WebExceptionStatus.Timeout)
-                        {
-                            // For connection timeout errors, include the connection timeout value that was used.
-                            var message = string.Format("{0} (HTTP request timeout was set to {1}ms)", ex.Message, httpRequest.Timeout);
-                            rethrowEx = new ConnectionException(message, response, ex.Status, httpRequest);
-                        }
-                        else
-                        {
-                            // Non-protocol errors indicate something happened with the underlying connection to the server.
-                            rethrowEx = new ConnectionException("Invalid HTTP response: " + ex.Message, response, ex.Status, httpRequest);
-                        }
+                          rethrowEx = new HttpException(ex.Message, response, httpWebResponse.StatusCode, ex.Status, httpWebResponse.Headers, httpRequest);
+                      }
+                      else if(ex.Status == WebExceptionStatus.ReceiveFailure ||
+                              ex.Status == WebExceptionStatus.ConnectFailure ||
+                              ex.Status == WebExceptionStatus.KeepAliveFailure)
+                      {
+                          logger.Debug("There was a problem connecting to the server: " + ex.Status.ToString());
+                          continue;
+                      }
+                      else if (ex.Status == WebExceptionStatus.Timeout)
+                      {
+                          // For connection timeout errors, include the connection timeout value that was used.
+                          var message = string.Format("{0} (HTTP request timeout was set to {1}ms)", ex.Message, httpRequest.Timeout);
+                          rethrowEx = new ConnectionException(message, response, ex.Status, httpRequest);
+                      }
+                      else
+                      {
+                          // Non-protocol errors indicate something happened with the underlying connection to the server.
+                          rethrowEx = new ConnectionException("Invalid HTTP response: " + ex.Message, response, ex.Status, httpRequest);
+                      }
 
-                        if(ex.Response != null && ex.Response is HttpWebResponse)
-                        {
-                            var httpWebResponse = ex.Response as HttpWebResponse;
-                            this.ResponseDetails.StatusCode = httpWebResponse.StatusCode;
-                            this.ResponseDetails.Headers = httpWebResponse.Headers;
-                        }
+                      if(ex.Response != null && ex.Response is HttpWebResponse)
+                      {
+                          var httpWebResponse = ex.Response as HttpWebResponse;
+                          this.ResponseDetails.StatusCode = httpWebResponse.StatusCode;
+                          this.ResponseDetails.Headers = httpWebResponse.Headers;
+                      }
 
-                        this.ResponseDetails.Exception = rethrowEx;
-                        throw rethrowEx;
-                    }
-                } while (retries++ < retriesConfigured);
+                      this.ResponseDetails.Exception = rethrowEx;
+                      throw rethrowEx;
+                  }
             }
             catch (PayPalException)
             {
@@ -344,7 +333,7 @@ namespace PayPal.Api
 
             // If we've gotten this far, it means all attempts at sending the
             // request resulted in a failed attempt.
-            throw new PayPalException("Retried " + retriesConfigured + " times.... Exception in PayPal.HttpConnection.Execute(). Check log for more details.");
+            throw new PayPalException("Exception in PayPal.HttpConnection.Execute(). Check log for more details.");
         }
     }
 }

--- a/Source/SDK/OpenIdConnect/Tokeninfo.cs
+++ b/Source/SDK/OpenIdConnect/Tokeninfo.cs
@@ -111,7 +111,6 @@ namespace PayPal.Api
                 apiContext = new APIContext();
             }
             apiContext.HTTPHeaders = headersMap;
-            apiContext.MaskRequestId = true;
             return PayPalResource.ConfigureAndExecute<Tokeninfo>(apiContext, HttpMethod.POST, resourcePath, payLoad);
         }
 
@@ -152,7 +151,6 @@ namespace PayPal.Api
                 apiContext = new APIContext();
             }
             apiContext.HTTPHeaders = headersMap;
-            apiContext.MaskRequestId = true;
 
             // Set the authentication header
             byte[] bytes = Encoding.UTF8.GetBytes(string.Format("{0}:{1}", apiContext.Config[BaseConstants.ClientId], apiContext.Config[BaseConstants.ClientSecret]));

--- a/Source/SDK/OpenIdConnect/Userinfo.cs
+++ b/Source/SDK/OpenIdConnect/Userinfo.cs
@@ -145,7 +145,6 @@ namespace PayPal.Api.OpenIdConnect
             {
                 apiContext = new APIContext();
             }
-            apiContext.MaskRequestId = true;
             return PayPalResource.ConfigureAndExecute<Userinfo>(apiContext, HttpMethod.GET, resourcePath, setAuthorizationHeader: false);
         }
     }

--- a/Source/Tests/APIContextTest.cs
+++ b/Source/Tests/APIContextTest.cs
@@ -10,7 +10,7 @@ namespace PayPal.Testing
         public void APIContextValidConstructorTest()
         {
             var apiContext = new APIContext();
-            Assert.IsFalse(string.IsNullOrEmpty(apiContext.RequestId));
+            Assert.IsTrue(string.IsNullOrEmpty(apiContext.RequestId));
             Assert.IsFalse(apiContext.MaskRequestId);
             Assert.IsTrue(string.IsNullOrEmpty(apiContext.AccessToken));
             Assert.IsNull(apiContext.Config);
@@ -22,7 +22,7 @@ namespace PayPal.Testing
         public void APIContextValidConstructorWithAccessTokenTest()
         {
             var apiContext = new APIContext("abc");
-            Assert.IsFalse(string.IsNullOrEmpty(apiContext.RequestId));
+            Assert.IsTrue(string.IsNullOrEmpty(apiContext.RequestId));
             Assert.IsFalse(apiContext.MaskRequestId);
             Assert.AreEqual("abc", apiContext.AccessToken);
             Assert.IsNull(apiContext.Config);


### PR DESCRIPTION
Due to a general misunderstanding on how the PayPal-Request-Id header is being used with retry logic, this PR removes automatically generating a PayPal-Request-Id value to be used. It also removes the automatic retries in order to let the users of the library control the retry logic more granularly.