### PR TITLE
Gives tooltip when using the nuget

### DIFF
--- a/Source/Core/PaypalEnvironment.cs
+++ b/Source/Core/PaypalEnvironment.cs
@@ -4,6 +4,9 @@ using BraintreeHttp;
 
 namespace PayPal.Core
 {
+    /// <summary>
+    /// Recommended to use SandboxEnvironment for testing or LiveEnvironment for production.
+    /// </summary>
     public class PayPalEnvironment : BraintreeHttp.Environment
     {
         private string baseUrl;
@@ -40,12 +43,18 @@ namespace PayPal.Core
         }
     }
 
+    /// <summary>
+    /// Use this environment for testing
+    /// </summary>
     public class SandboxEnvironment : PayPalEnvironment
     {
         public SandboxEnvironment(string clientId, string clientSecret) : base(clientId, clientSecret, "https://api.sandbox.paypal.com", "https://www.sandbox.paypal.com")
         { }
     }
 
+    /// <summary>
+    /// This is the production environment
+    /// </summary>
     public class LiveEnvironment : PayPalEnvironment
     {
         public LiveEnvironment(string clientId, string clientSecret) : base(clientId, clientSecret, "https://api.paypal.com", "https://www.paypal.com")

--- a/Source/v1/Payments/PaymentCreateRequest.cs
+++ b/Source/v1/Payments/PaymentCreateRequest.cs
@@ -15,7 +15,11 @@ using BraintreeHttp;
 namespace PayPal.v1.Payments
 {
     /// <summary>
-    /// Creates a sale, an authorized payment to be captured later, or an order. To create a sale, authorization, or order, include the payment details in the JSON request body. Set the `intent` to `sale`, `authorize`, or `order`. Include payer, transaction details, and, for PayPal payments only, redirect URLs. The combination of the `payment_method` and `funding_instrument` determines the type of payment that is created. For more information, see [Payments REST API](/docs/integration/direct/payments/).<blockquote><strong>Note:</strong> Authorizations are guaranteed for up to three days, though you can attempt to capture an authorization for up to 29 days. After the three-day honor period authorization expires, you can [reauthorize](#authorization_reauthorize) the payment.</blockquote>
+    /// Creates a Sale, an authorized Payment to be captured later, or an Order. To create a Sale, Authorization, or Order, include the payment details in the JSON request body. 
+    /// Set the `Intent` to `Sale`, `Authorize`, or `Order`. Include Payer, transaction details, and, for PayPal payments only, redirect URLs. 
+    /// The combination of the `PaymentMethod` and `FundingInstrument` determines the type of payment that is created. 
+    /// For more information, see [Payments REST API](/docs/integration/direct/payments/).<blockquote><strong>Note:</strong> Authorizations are guaranteed for up to three days, though 
+    /// you can attempt to capture an authorization for up to 29 days. After the three-day honor period authorization expires, you can [reauthorize](#authorization_reauthorize) the payment.</blockquote>
     /// </summary>
     public class PaymentCreateRequest : HttpRequest
     {


### PR DESCRIPTION
My first PR to add a tooltip when you are working with the 2.x beta Nuget. Makes it a bit more clear not to use paypalenvironment directly. Because there are no docs yet.
![4w6a7sg](https://user-images.githubusercontent.com/1119134/35850672-e10499d4-0b25-11e8-9e3a-55b069caf9ba.gif)
